### PR TITLE
refact: JDK 17 + Spring Boot 3.1.2 버전 업데이트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,8 @@
-//querydsl 추가
-buildscript {
-	ext {
-		queryDslVersion = "5.0.0"
-	}
-}
-
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.1.2'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 	id 'org.asciidoctor.jvm.convert' version '3.3.2'
-	//querydsl 추가
-	id 'com.ewerk.gradle.plugins.querydsl' version '1.0.10'
 	id 'com.google.cloud.tools.jib' version '3.3.1'
 }
 
@@ -49,11 +40,8 @@ jib {
 		tags = ["latest"]
 	}
 	container {
-		// Set docker image creation time
 		creationTime = 'USE_CURRENT_TIMESTAMP'
-		// Set JVM options.
 		jvmFlags = ['-Dspring.profiles.active=prod', '-XX:+UseContainerSupport', '-Dserver.port=8080', '-Dfile.encoding=UTF-8']
-		// Expose different port.
 		ports = ['8080']
 		extraDirectories {
 			paths {
@@ -72,8 +60,6 @@ tasks.named('jib') {
 
 asciidoctor {
 	forkOptions {
-		// jvm 옵션. spring rest docs가 sun.nio.ch과 java.io 패키지를 사용하게 할 수 있게끔 설정
-		// HTTP 테스트 중에 요청과 응답을 캡쳐하는데, 운영체제와 네트워크 레이어의 io를 획득하기 위해 사용.
 		jvmArgs('--add-opens', 'java.base/sun.nio.ch=ALL-UNNAMED')
 		jvmArgs('--add-opens', 'java.base/java.io=ALL-UNNAMED')
 	}
@@ -83,7 +69,7 @@ asciidoctor {
 	sources {
 		include("**/index.adoc")
 	}
-	baseDirFollowsSourceDir() // 특정 .adoc에 다른 adoc 파일을 가져와서 사용하고 싶을 경우 설정
+	baseDirFollowsSourceDir()
 }
 
 asciidoctor.doFirst {
@@ -108,7 +94,7 @@ build {
 }
 
 clean {
-	delete file('src/main/generated') // 인텔리제이 Annotation processor 생성물 생성 위치
+	delete file('src/main/generated')
 }
 
 dependencyManagement {
@@ -125,8 +111,7 @@ dependencies {
 	implementation 'com.nimbusds:nimbus-jose-jwt:9.29'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
-	implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
+	implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
 	implementation platform('com.amazonaws:aws-java-sdk-bom:1.11.238')
 	implementation 'com.amazonaws:aws-java-sdk-s3'
 	implementation 'com.github.maricn:logback-slack-appender:1.4.0'
@@ -136,10 +121,9 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5', 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
 	annotationProcessor 'org.projectlombok:lombok'
-	// java.lang.NoClassDefFoundError(javax.annotation.Entity) 발생 대응
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
-	// java.lang.NoClassDefFoundError(javax.annotation.Generated) 발생 대응
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	testImplementation 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -154,16 +138,13 @@ tasks.named('test') {
 //querydsl 추가
 def querydslDir = "$buildDir/generated/querydsl"
 
-querydsl {
-	jpa = true
-	querydslSourcesDir = querydslDir
+tasks.withType(JavaCompile) {
+	options.generatedSourceOutputDirectory = file(querydslDir)
 }
 sourceSets {
 	main.java.srcDir querydslDir
 }
-compileQuerydsl {
-	options.annotationProcessorPath = configurations.querydsl
-}
+
 configurations {
 	compileOnly {
 		extendsFrom annotationProcessor

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '2.7.7'
+	id 'org.springframework.boot' version '3.1.2'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 	id 'org.asciidoctor.jvm.convert' version '3.3.2'
 	//querydsl 추가
@@ -17,7 +17,7 @@ plugins {
 
 group = 'com.nexters'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
+sourceCompatibility = '17'
 
 configurations {
 	asciidoctorExtensions

--- a/document/refactoring_1_0_0.md
+++ b/document/refactoring_1_0_0.md
@@ -3,7 +3,7 @@
 ### 1. 자바 및 스프링 버전 업그레이드
 record, lambda 최신 문법 등의 사용에 제약이 있었습니다. 
 - Java 11 -> Java 17
-- Spring Boot 2.4.5 -> Spring Boot 3.1.0
+- Spring Boot 2.7.7 -> Spring Boot 3.1.2
 
 ### 2. 패키지 구조 변경
 기존 방식들의 패키지 관리가 어려워졌습니다.

--- a/src/main/java/com/nexters/phochak/PhochakApplication.java
+++ b/src/main/java/com/nexters/phochak/PhochakApplication.java
@@ -1,11 +1,16 @@
 package com.nexters.phochak;
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.cloud.openfeign.FeignAutoConfiguration;
 
 @ConfigurationPropertiesScan
 @SpringBootApplication
+@ImportAutoConfiguration({FeignAutoConfiguration.class})
+@EnableFeignClients("com.nexters.phochak")
 public class PhochakApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/nexters/phochak/auth/aspect/AuthAspect.java
+++ b/src/main/java/com/nexters/phochak/auth/aspect/AuthAspect.java
@@ -6,6 +6,7 @@ import com.nexters.phochak.auth.application.JwtTokenServiceImpl;
 import com.nexters.phochak.common.exception.PhochakException;
 import com.nexters.phochak.common.exception.ResCode;
 import com.nexters.phochak.user.application.UserService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -13,8 +14,6 @@ import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
-
-import javax.servlet.http.HttpServletRequest;
 
 import static com.nexters.phochak.auth.TokenDto.TOKEN_TYPE;
 

--- a/src/main/java/com/nexters/phochak/auth/domain/RefreshToken.java
+++ b/src/main/java/com/nexters/phochak/auth/domain/RefreshToken.java
@@ -1,12 +1,11 @@
 package com.nexters.phochak.auth.domain;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
-
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 
 @NoArgsConstructor
 

--- a/src/main/java/com/nexters/phochak/auth/presentation/AuthController.java
+++ b/src/main/java/com/nexters/phochak/auth/presentation/AuthController.java
@@ -4,14 +4,13 @@ import com.nexters.phochak.auth.JwtResponseDto;
 import com.nexters.phochak.auth.application.JwtTokenService;
 import com.nexters.phochak.post.CommonResponse;
 import com.nexters.phochak.user.application.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import javax.validation.Valid;
 
 @Slf4j
 @RequiredArgsConstructor

--- a/src/main/java/com/nexters/phochak/auth/presentation/LoginRequestDto.java
+++ b/src/main/java/com/nexters/phochak/auth/presentation/LoginRequestDto.java
@@ -1,9 +1,8 @@
 package com.nexters.phochak.auth.presentation;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-
-import javax.validation.constraints.NotBlank;
 
 @Getter
 @AllArgsConstructor

--- a/src/main/java/com/nexters/phochak/auth/presentation/LoginV2RequestDto.java
+++ b/src/main/java/com/nexters/phochak/auth/presentation/LoginV2RequestDto.java
@@ -1,9 +1,8 @@
 package com.nexters.phochak.auth.presentation;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-
-import javax.validation.constraints.NotBlank;
 
 @Getter
 @AllArgsConstructor

--- a/src/main/java/com/nexters/phochak/common/config/QueryDslConfig.java
+++ b/src/main/java/com/nexters/phochak/common/config/QueryDslConfig.java
@@ -1,12 +1,11 @@
 package com.nexters.phochak.common.config;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 
 @EnableJpaAuditing
 @Configuration

--- a/src/main/java/com/nexters/phochak/common/config/property/FirebaseProperties.java
+++ b/src/main/java/com/nexters/phochak/common/config/property/FirebaseProperties.java
@@ -3,11 +3,9 @@ package com.nexters.phochak.common.config.property;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
 
 @Getter
 @RequiredArgsConstructor
-@ConstructorBinding
 @ConfigurationProperties(prefix = "firebase")
 public class FirebaseProperties {
     private final String firebaseScope;

--- a/src/main/java/com/nexters/phochak/common/config/property/JwtProperties.java
+++ b/src/main/java/com/nexters/phochak/common/config/property/JwtProperties.java
@@ -3,11 +3,9 @@ package com.nexters.phochak.common.config.property;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
 
 @Getter
 @RequiredArgsConstructor
-@ConstructorBinding
 @ConfigurationProperties(prefix = "jwt.token")
 public class JwtProperties {
     private final String secretKey;

--- a/src/main/java/com/nexters/phochak/common/config/property/KakaoLoginProperties.java
+++ b/src/main/java/com/nexters/phochak/common/config/property/KakaoLoginProperties.java
@@ -3,11 +3,9 @@ package com.nexters.phochak.common.config.property;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
 
 @Getter
 @RequiredArgsConstructor
-@ConstructorBinding
 @ConfigurationProperties(prefix = "kakao")
 public class KakaoLoginProperties {
     private final String clientId;

--- a/src/main/java/com/nexters/phochak/common/config/property/NCPStorageProperties.java
+++ b/src/main/java/com/nexters/phochak/common/config/property/NCPStorageProperties.java
@@ -3,11 +3,9 @@ package com.nexters.phochak.common.config.property;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
 
 @Getter
 @RequiredArgsConstructor
-@ConstructorBinding
 @ConfigurationProperties(prefix = "ncp")
 public class NCPStorageProperties {
 

--- a/src/main/java/com/nexters/phochak/common/config/property/RedisProperties.java
+++ b/src/main/java/com/nexters/phochak/common/config/property/RedisProperties.java
@@ -3,11 +3,9 @@ package com.nexters.phochak.common.config.property;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
 
 @Getter
 @RequiredArgsConstructor
-@ConstructorBinding
 @ConfigurationProperties(prefix = "spring.redis")
 public class RedisProperties {
     private final String host;

--- a/src/main/java/com/nexters/phochak/common/config/property/SlackReportProperties.java
+++ b/src/main/java/com/nexters/phochak/common/config/property/SlackReportProperties.java
@@ -3,11 +3,9 @@ package com.nexters.phochak.common.config.property;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
 
 @Getter
 @RequiredArgsConstructor
-@ConstructorBinding
 @ConfigurationProperties(prefix = "slack.report")
 public class SlackReportProperties {
     private final String botNickname;

--- a/src/main/java/com/nexters/phochak/common/domain/BaseTime.java
+++ b/src/main/java/com/nexters/phochak/common/domain/BaseTime.java
@@ -1,13 +1,13 @@
 package com.nexters.phochak.common.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import javax.persistence.EntityListeners;
-import javax.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 
 @Getter

--- a/src/main/java/com/nexters/phochak/common/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/nexters/phochak/common/exception/CustomExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.nexters.phochak.common.exception;
 
 import com.nexters.phochak.post.CommonResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,7 +14,6 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
-import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 
 @Slf4j

--- a/src/main/java/com/nexters/phochak/hashtag/domain/Hashtag.java
+++ b/src/main/java/com/nexters/phochak/hashtag/domain/Hashtag.java
@@ -1,22 +1,21 @@
 package com.nexters.phochak.hashtag.domain;
 
 import com.nexters.phochak.post.domain.Post;
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
-
-import javax.persistence.Column;
-import javax.persistence.ConstraintMode;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.ForeignKey;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Index;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
-import javax.validation.constraints.Size;
 
 @Getter
 @Entity

--- a/src/main/java/com/nexters/phochak/ignore/domain/IgnoredUsers.java
+++ b/src/main/java/com/nexters/phochak/ignore/domain/IgnoredUsers.java
@@ -1,10 +1,9 @@
 package com.nexters.phochak.ignore.domain;
 
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
 import lombok.Builder;
 import lombok.Getter;
-
-import javax.persistence.EmbeddedId;
-import javax.persistence.Entity;
 
 @Getter
 @Entity

--- a/src/main/java/com/nexters/phochak/ignore/domain/IgnoredUsersRelation.java
+++ b/src/main/java/com/nexters/phochak/ignore/domain/IgnoredUsersRelation.java
@@ -1,16 +1,16 @@
 package com.nexters.phochak.ignore.domain;
 
 import com.nexters.phochak.user.domain.User;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.ConstraintMode;
-import javax.persistence.Embeddable;
-import javax.persistence.FetchType;
-import javax.persistence.ForeignKey;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import java.io.Serializable;
 
 @Getter

--- a/src/main/java/com/nexters/phochak/likes/domain/Likes.java
+++ b/src/main/java/com/nexters/phochak/likes/domain/Likes.java
@@ -3,21 +3,21 @@ package com.nexters.phochak.likes.domain;
 import com.nexters.phochak.common.domain.BaseTime;
 import com.nexters.phochak.post.domain.Post;
 import com.nexters.phochak.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
 
-import javax.persistence.Column;
-import javax.persistence.ConstraintMode;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.ForeignKey;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Index;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
 import java.util.Objects;
 
 @Getter

--- a/src/main/java/com/nexters/phochak/notification/domain/FcmDeviceToken.java
+++ b/src/main/java/com/nexters/phochak/notification/domain/FcmDeviceToken.java
@@ -2,17 +2,16 @@ package com.nexters.phochak.notification.domain;
 
 import com.nexters.phochak.common.domain.BaseTime;
 import com.nexters.phochak.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import lombok.Builder;
 import lombok.Getter;
-
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.OneToOne;
 
 @Getter
 @Entity

--- a/src/main/java/com/nexters/phochak/post/PostCreateRequestDto.java
+++ b/src/main/java/com/nexters/phochak/post/PostCreateRequestDto.java
@@ -1,12 +1,12 @@
 package com.nexters.phochak.post;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
 import java.util.List;
 
 @Getter

--- a/src/main/java/com/nexters/phochak/post/PostUpdateRequestDto.java
+++ b/src/main/java/com/nexters/phochak/post/PostUpdateRequestDto.java
@@ -1,12 +1,12 @@
 package com.nexters.phochak.post;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
 import java.util.List;
 
 @Getter

--- a/src/main/java/com/nexters/phochak/post/domain/Post.java
+++ b/src/main/java/com/nexters/phochak/post/domain/Post.java
@@ -6,31 +6,30 @@ import com.nexters.phochak.likes.domain.Likes;
 import com.nexters.phochak.report.domain.ReportPost;
 import com.nexters.phochak.shorts.domain.Shorts;
 import com.nexters.phochak.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.ToString;
 import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.annotations.Type;
+import org.hibernate.type.YesNoConverter;
 
-import javax.persistence.Column;
-import javax.persistence.ConstraintMode;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
-import javax.persistence.ForeignKey;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Index;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
 import java.util.List;
 
-@ToString
 @Getter
 @Entity
 @Table(indexes =
@@ -64,7 +63,7 @@ public class Post extends BaseTime {
     private PostCategoryEnum postCategory;
 
     @Column(nullable = false, columnDefinition = "CHAR(1) DEFAULT 'N'")
-    @Type(type = "yes_no")
+    @Convert(converter = YesNoConverter.class)
     private boolean isBlind;
 
     @OneToMany(mappedBy = "post")

--- a/src/main/java/com/nexters/phochak/post/presentation/PostController.java
+++ b/src/main/java/com/nexters/phochak/post/presentation/PostController.java
@@ -11,6 +11,7 @@ import com.nexters.phochak.post.PostUpdateRequestDto;
 import com.nexters.phochak.post.application.PostService;
 import com.nexters.phochak.report.application.ReportPostService;
 import com.nexters.phochak.shorts.PostUploadKeyResponseDto;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -23,7 +24,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.validation.Valid;
 import java.util.List;
 
 @Slf4j

--- a/src/main/java/com/nexters/phochak/report/domain/ReportPost.java
+++ b/src/main/java/com/nexters/phochak/report/domain/ReportPost.java
@@ -3,21 +3,20 @@ package com.nexters.phochak.report.domain;
 import com.nexters.phochak.common.domain.BaseTime;
 import com.nexters.phochak.post.domain.Post;
 import com.nexters.phochak.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
-
-import javax.persistence.Column;
-import javax.persistence.ConstraintMode;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.ForeignKey;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Index;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
 
 @Getter
 @Entity

--- a/src/main/java/com/nexters/phochak/shorts/domain/Shorts.java
+++ b/src/main/java/com/nexters/phochak/shorts/domain/Shorts.java
@@ -1,16 +1,15 @@
 package com.nexters.phochak.shorts.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import lombok.Builder;
 import lombok.Getter;
-
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 
 @Entity
 @Getter

--- a/src/main/java/com/nexters/phochak/user/NicknameModifyRequestDto.java
+++ b/src/main/java/com/nexters/phochak/user/NicknameModifyRequestDto.java
@@ -1,10 +1,9 @@
 package com.nexters.phochak.user;
 
 import com.nexters.phochak.user.domain.User;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
-
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
 
 @Getter
 public class NicknameModifyRequestDto {

--- a/src/main/java/com/nexters/phochak/user/domain/User.java
+++ b/src/main/java/com/nexters/phochak/user/domain/User.java
@@ -2,20 +2,21 @@ package com.nexters.phochak.user.domain;
 
 import com.nexters.phochak.common.domain.BaseTime;
 import com.nexters.phochak.notification.domain.FcmDeviceToken;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
-import org.hibernate.annotations.Type;
+import org.hibernate.type.YesNoConverter;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
-import javax.validation.constraints.Size;
 import java.time.LocalDateTime;
 
 @Getter
@@ -45,7 +46,7 @@ public class User extends BaseTime {
     private String profileImgUrl;
 
     @Column(nullable = false, columnDefinition = "CHAR(1) DEFAULT 'N'")
-    @Type(type = "yes_no")
+    @Convert(converter = YesNoConverter.class)
     private Boolean isBlocked = false;
 
     private LocalDateTime leaveDate;

--- a/src/main/java/com/nexters/phochak/user/presentation/UserController.java
+++ b/src/main/java/com/nexters/phochak/user/presentation/UserController.java
@@ -15,6 +15,7 @@ import com.nexters.phochak.user.NicknameModifyRequestDto;
 import com.nexters.phochak.user.UserCheckResponseDto;
 import com.nexters.phochak.user.UserInfoResponseDto;
 import com.nexters.phochak.user.application.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -26,8 +27,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import javax.validation.Valid;
 
 @Slf4j
 @RequiredArgsConstructor

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,12 +2,12 @@ spring:
   datasource:
     driver-class-name: com.mysql.jdbc.Driver
     url: jdbc:mysql://localhost:3306/phochak
-    username: phochak
-    password: qpdjrmflftm
+    username: root
+    password: 1234
   jpa:
     generate-ddl: true
     hibernate:
-      ddl-auto: validate
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true

--- a/src/test/java/com/nexters/phochak/deprecated/auth/aspect/AuthAspectTest.java
+++ b/src/test/java/com/nexters/phochak/deprecated/auth/aspect/AuthAspectTest.java
@@ -5,6 +5,7 @@ import com.nexters.phochak.auth.aspect.AuthAspect;
 import com.nexters.phochak.common.exception.PhochakException;
 import com.nexters.phochak.common.exception.ResCode;
 import com.nexters.phochak.user.application.UserServiceImpl;
+import jakarta.servlet.http.HttpServletRequest;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -13,8 +14,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import javax.servlet.http.HttpServletRequest;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.*;

--- a/src/test/java/com/nexters/phochak/deprecated/controller/PostControllerTest.java
+++ b/src/test/java/com/nexters/phochak/deprecated/controller/PostControllerTest.java
@@ -32,9 +32,9 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.headerWit
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @Deprecated
@@ -149,9 +149,9 @@ class PostControllerTest extends RestDocs {
                 .andDo(document("post/list/initial",
                         preprocessRequest(modifyUris().scheme("http").host("101.101.209.228").removePort(), prettyPrint()),
                         preprocessResponse(prettyPrint()),
-                        requestParameters(
-                                parameterWithName("sortOption").description("(필수) 게시글 정렬 기준 (LIKE/LATEST/VIEW)"),
-                                parameterWithName("pageSize").description("(선택) 페이지 크기(default: 5)").optional()
+                        requestFields(
+                                fieldWithPath("sortOption").description("(필수) 게시글 정렬 기준 (LIKE/LATEST/VIEW)"),
+                                fieldWithPath("pageSize").description("(선택) 페이지 크기(default: 5)").optional()
                         ),
                         requestHeaders(
                                 headerWithName(AUTHORIZATION_HEADER)
@@ -221,11 +221,11 @@ class PostControllerTest extends RestDocs {
                 .andDo(document("post/list/after",
                         preprocessRequest(modifyUris().scheme("http").host("101.101.209.228").removePort(), prettyPrint()),
                         preprocessResponse(prettyPrint()),
-                        requestParameters(
-                                parameterWithName("sortOption").description("(필수) 게시글 정렬 기준 (LIKE/LATEST/VIEW)"),
-                                parameterWithName("sortValue").description("(sortOption이 LATEST인 경우를 제외하고 필수) 마지막으로 받은 페이지의 마지막 게시글의 정렬 기준 값(LIKE면 좋아요 수, VIEW면 조회수)"),
-                                parameterWithName("lastId").description("(필수) 마지막으로 받은 게시글 id"),
-                                parameterWithName("pageSize").description("(선택) 페이지 크기(default: 5)").optional()
+                        requestFields(
+                                fieldWithPath("sortOption").description("(필수) 게시글 정렬 기준 (LIKE/LATEST/VIEW)"),
+                                fieldWithPath("sortValue").description("(sortOption이 LATEST인 경우를 제외하고 필수) 마지막으로 받은 페이지의 마지막 게시글의 정렬 기준 값(LIKE면 좋아요 수, VIEW면 조회수)"),
+                                fieldWithPath("lastId").description("(필수) 마지막으로 받은 게시글 id"),
+                                fieldWithPath("pageSize").description("(선택) 페이지 크기(default: 5)").optional()
                         ),
                         requestHeaders(
                                 headerWithName(AUTHORIZATION_HEADER)
@@ -295,11 +295,11 @@ class PostControllerTest extends RestDocs {
                 .andDo(document("post/list/last",
                         preprocessRequest(modifyUris().scheme("http").host("101.101.209.228").removePort(), prettyPrint()),
                         preprocessResponse(prettyPrint()),
-                        requestParameters(
-                                parameterWithName("sortOption").description("(필수) 게시글 정렬 기준 (LIKE/LATEST/VIEW)"),
-                                parameterWithName("sortValue").description("(sortOption이 LATEST인 경우를 제외하고 필수) 마지막으로 받은 페이지의 마지막 게시글의 정렬 기준 값(LIKE면 좋아요 수, VIEW면 조회수)"),
-                                parameterWithName("lastId").description("(필수) 마지막으로 받은 게시글 id"),
-                                parameterWithName("pageSize").description("(선택) 페이지 크기(default: 5)").optional()
+                        requestFields(
+                                fieldWithPath("sortOption").description("(필수) 게시글 정렬 기준 (LIKE/LATEST/VIEW)"),
+                                fieldWithPath("sortValue").description("(sortOption이 LATEST인 경우를 제외하고 필수) 마지막으로 받은 페이지의 마지막 게시글의 정렬 기준 값(LIKE면 좋아요 수, VIEW면 조회수)"),
+                                fieldWithPath("lastId").description("(필수) 마지막으로 받은 게시글 id"),
+                                fieldWithPath("pageSize").description("(선택) 페이지 크기(default: 5)").optional()
                         ),
                         requestHeaders(
                                 headerWithName(AUTHORIZATION_HEADER)
@@ -379,13 +379,13 @@ class PostControllerTest extends RestDocs {
                 .andDo(document("post/list/uploaded",
                         preprocessRequest(modifyUris().scheme("http").host("101.101.209.228").removePort(), prettyPrint()),
                         preprocessResponse(prettyPrint()),
-                        requestParameters(
-                                parameterWithName("sortOption").description("(필수) 게시글 정렬 기준 (LIKE/LATEST/VIEW)"),
-                                parameterWithName("sortValue").description("(sortOption이 LATEST인 경우를 제외하고 필수) 마지막으로 받은 페이지의 마지막 게시글의 정렬 기준 값(LIKE면 좋아요 수, VIEW면 조회수)"),
-                                parameterWithName("lastId").description("(필수) 마지막으로 받은 게시글 id"),
-                                parameterWithName("pageSize").description("(선택) 페이지 크기(default: 5)").optional(),
-                                parameterWithName("filter").description("(선택) 마이페이지 필터 조건 (UPLOADED: 내가 업로드한 동영상/LIKED: 내가 좋아요한 동영상)"),
-                                parameterWithName("targetUserId").description("(선택) 조회할 페이지의 유저 id (본인의 페이지라면 생략 가능)")
+                        requestFields(
+                                fieldWithPath("sortOption").description("(필수) 게시글 정렬 기준 (LIKE/LATEST/VIEW)"),
+                                fieldWithPath("sortValue").description("(sortOption이 LATEST인 경우를 제외하고 필수) 마지막으로 받은 페이지의 마지막 게시글의 정렬 기준 값(LIKE면 좋아요 수, VIEW면 조회수)"),
+                                fieldWithPath("lastId").description("(필수) 마지막으로 받은 게시글 id"),
+                                fieldWithPath("pageSize").description("(선택) 페이지 크기(default: 5)").optional(),
+                                fieldWithPath("filter").description("(선택) 마이페이지 필터 조건 (UPLOADED: 내가 업로드한 동영상/LIKED: 내가 좋아요한 동영상)"),
+                                fieldWithPath("targetUserId").description("(선택) 조회할 페이지의 유저 id (본인의 페이지라면 생략 가능)")
                         ),
                         requestHeaders(
                                 headerWithName(AUTHORIZATION_HEADER)
@@ -463,12 +463,12 @@ class PostControllerTest extends RestDocs {
                 .andDo(document("post/list/liked",
                         preprocessRequest(modifyUris().scheme("http").host("101.101.209.228").removePort(), prettyPrint()),
                         preprocessResponse(prettyPrint()),
-                        requestParameters(
-                                parameterWithName("sortOption").description("(필수) 게시글 정렬 기준 (LIKE/LATEST/VIEW)"),
-                                parameterWithName("sortValue").description("(sortOption이 LATEST인 경우를 제외하고 필수) 마지막으로 받은 페이지의 마지막 게시글의 정렬 기준 값(LIKE면 좋아요 수, VIEW면 조회수)"),
-                                parameterWithName("lastId").description("(필수) 마지막으로 받은 게시글 id"),
-                                parameterWithName("pageSize").description("(선택) 페이지 크기(default: 5)").optional(),
-                                parameterWithName("filter").description("(선택) 마이페이지 필터 조건 (UPLOADED: 내가 업로드한 동영상/LIKED: 내가 좋아요한 동영상)")
+                        requestFields(
+                                fieldWithPath("sortOption").description("(필수) 게시글 정렬 기준 (LIKE/LATEST/VIEW)"),
+                                fieldWithPath("sortValue").description("(sortOption이 LATEST인 경우를 제외하고 필수) 마지막으로 받은 페이지의 마지막 게시글의 정렬 기준 값(LIKE면 좋아요 수, VIEW면 조회수)"),
+                                fieldWithPath("lastId").description("(필수) 마지막으로 받은 게시글 id"),
+                                fieldWithPath("pageSize").description("(선택) 페이지 크기(default: 5)").optional(),
+                                fieldWithPath("filter").description("(선택) 마이페이지 필터 조건 (UPLOADED: 내가 업로드한 동영상/LIKED: 내가 좋아요한 동영상)")
                         ),
                         requestHeaders(
                                 headerWithName(AUTHORIZATION_HEADER)
@@ -543,11 +543,11 @@ class PostControllerTest extends RestDocs {
                 .andDo(document("post/list/search",
                         preprocessRequest(modifyUris().scheme("http").host("101.101.209.228").removePort(), prettyPrint()),
                         preprocessResponse(prettyPrint()),
-                        requestParameters(
-                                parameterWithName("lastId").description("(선택) 마지막으로 받은 게시글 id"),
-                                parameterWithName("pageSize").description("(선택) 페이지 크기(default: 5)").optional(),
-                                parameterWithName("hashtag").description("(선택) 검색할 해시태그").optional(),
-                                parameterWithName("category").description("(선택) 게시글 카테고리 ex) CAFE").optional()
+                        requestFields(
+                                fieldWithPath("lastId").description("(선택) 마지막으로 받은 게시글 id"),
+                                fieldWithPath("pageSize").description("(선택) 페이지 크기(default: 5)").optional(),
+                                fieldWithPath("hashtag").description("(선택) 검색할 해시태그").optional(),
+                                fieldWithPath("category").description("(선택) 게시글 카테고리 ex) CAFE").optional()
                         ),
                         requestHeaders(
                                 headerWithName(AUTHORIZATION_HEADER)
@@ -595,9 +595,9 @@ class PostControllerTest extends RestDocs {
                 .andDo(document("post/hashtag/autocomplete",
                         preprocessRequest(modifyUris().scheme("http").host("101.101.209.228").removePort(), prettyPrint()),
                         preprocessResponse(prettyPrint()),
-                        requestParameters(
-                                parameterWithName("hashtag").description("(필수) 검색할 해시태그").optional(),
-                                parameterWithName("resultSize").description("(필수) 검색 결과 크기").optional()
+                        requestFields(
+                                fieldWithPath("hashtag").description("(필수) 검색할 해시태그").optional(),
+                                fieldWithPath("resultSize").description("(필수) 검색 결과 크기").optional()
                         ),
                         requestHeaders(
                                 headerWithName(AUTHORIZATION_HEADER)

--- a/src/test/java/com/nexters/phochak/deprecated/controller/UserControllerTest.java
+++ b/src/test/java/com/nexters/phochak/deprecated/controller/UserControllerTest.java
@@ -37,7 +37,8 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.requestHe
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @Deprecated
@@ -85,8 +86,8 @@ class UserControllerTest extends RestDocs {
                                 pathParameters(
                                         parameterWithName("provider").description("(필수) OAuth 서비스 이름(ex. kakao, apple, naver)")
                                 ),
-                                requestParameters(
-                                        parameterWithName("token").description("(필수) token (Access token or Identify Token)")
+                                requestFields(
+                                        fieldWithPath("token").description("(필수) token (Access token or Identify Token)")
                                 ),
                                 responseFields(
                                         fieldWithPath("status.resCode").type(JsonFieldType.STRING).description("응답 코드"),
@@ -116,8 +117,8 @@ class UserControllerTest extends RestDocs {
                 .andDo(document("user/check/nickname",
                         preprocessRequest(modifyUris().scheme("http").host("101.101.209.228").removePort(), prettyPrint()),
                         preprocessResponse(prettyPrint()),
-                        requestParameters(
-                                parameterWithName("nickname").description("(필수) 중복확인하고자 하는 닉네임 ('#' 때문에 URL 인코딩 처리해주세요)")
+                        requestFields(
+                                fieldWithPath("nickname").description("(필수) 중복확인하고자 하는 닉네임 ('#' 때문에 URL 인코딩 처리해주세요)")
                         ),
                         responseFields(
                                 fieldWithPath("status.resCode").type(JsonFieldType.STRING).description("응답 코드"),

--- a/src/test/java/com/nexters/phochak/deprecated/controller/UserV2ControllerTest.java
+++ b/src/test/java/com/nexters/phochak/deprecated/controller/UserV2ControllerTest.java
@@ -21,9 +21,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @Deprecated
@@ -72,9 +72,9 @@ class UserV2ControllerTest extends RestDocs {
                         pathParameters(
                                 parameterWithName("provider").description("(필수) OAuth 서비스 이름(ex. kakao, apple, naver)")
                         ),
-                        requestParameters(
-                                parameterWithName("token").description("(필수) token (Access token or Identify Token)"),
-                                parameterWithName("fcmDeviceToken").description("(필수) FCM client 식별 토큰")
+                        requestFields(
+                                fieldWithPath("token").description("(필수) token (Access token or Identify Token)"),
+                                fieldWithPath("fcmDeviceToken").description("(필수) FCM client 식별 토큰")
                         ),
                         responseFields(
                                 fieldWithPath("status.resCode").type(JsonFieldType.STRING).description("응답 코드"),

--- a/src/test/java/com/nexters/phochak/deprecated/integration/AuthIntegrationTest.java
+++ b/src/test/java/com/nexters/phochak/deprecated/integration/AuthIntegrationTest.java
@@ -21,6 +21,7 @@ import com.nexters.phochak.user.domain.OAuthProviderEnum;
 import com.nexters.phochak.user.domain.User;
 import com.nexters.phochak.user.domain.UserRepository;
 import com.nexters.phochak.user.presentation.UserController;
+import jakarta.persistence.EntityManager;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -37,7 +38,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.persistence.EntityManager;
 import java.util.List;
 
 import static com.nexters.phochak.auth.aspect.AuthAspect.AUTHORIZATION_HEADER;

--- a/src/test/java/com/nexters/phochak/deprecated/integration/LikesIntegrationTest.java
+++ b/src/test/java/com/nexters/phochak/deprecated/integration/LikesIntegrationTest.java
@@ -17,6 +17,7 @@ import com.nexters.phochak.shorts.domain.ShortsRepository;
 import com.nexters.phochak.user.domain.OAuthProviderEnum;
 import com.nexters.phochak.user.domain.User;
 import com.nexters.phochak.user.domain.UserRepository;
+import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,8 +29,6 @@ import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
-
-import javax.transaction.Transactional;
 
 import static com.nexters.phochak.auth.aspect.AuthAspect.AUTHORIZATION_HEADER;
 import static com.nexters.phochak.common.exception.ResCode.OK;

--- a/src/test/java/com/nexters/phochak/deprecated/integration/PostIntegrationTest.java
+++ b/src/test/java/com/nexters/phochak/deprecated/integration/PostIntegrationTest.java
@@ -5,6 +5,7 @@ import com.nexters.phochak.post.application.PostServiceImpl;
 import com.nexters.phochak.post.domain.Post;
 import com.nexters.phochak.post.domain.PostCategoryEnum;
 import com.nexters.phochak.post.domain.PostRepository;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,7 +14,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.persistence.EntityManager;
 import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;

--- a/src/test/java/com/nexters/phochak/deprecated/integration/PostNcpIntegrationTest.java
+++ b/src/test/java/com/nexters/phochak/deprecated/integration/PostNcpIntegrationTest.java
@@ -19,6 +19,7 @@ import com.nexters.phochak.shorts.presentation.NCPStorageClient;
 import com.nexters.phochak.user.domain.OAuthProviderEnum;
 import com.nexters.phochak.user.domain.User;
 import com.nexters.phochak.user.domain.UserRepository;
+import jakarta.persistence.EntityManager;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -35,7 +36,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.persistence.EntityManager;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -53,7 +53,8 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -116,8 +117,8 @@ class PostNcpIntegrationTest extends RestDocs {
                 .andDo(document("post/upload-key/GET",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
-                        requestParameters(
-                                parameterWithName("file-extension").description("파일 생성자 ex) mp4")
+                        requestFields(
+                                fieldWithPath("file-extension").description("파일 생성자 ex) mp4")
                         ),
                         requestHeaders(
                                 headerWithName(AUTHORIZATION_HEADER)

--- a/src/test/java/com/nexters/phochak/deprecated/repository/FcmDeviceTokenRepositoryTest.java
+++ b/src/test/java/com/nexters/phochak/deprecated/repository/FcmDeviceTokenRepositoryTest.java
@@ -10,6 +10,7 @@ import com.nexters.phochak.shorts.domain.ShortsRepository;
 import com.nexters.phochak.user.domain.OAuthProviderEnum;
 import com.nexters.phochak.user.domain.User;
 import com.nexters.phochak.user.domain.UserRepository;
+import jakarta.persistence.EntityManager;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,7 +19,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.persistence.EntityManager;
 import java.util.List;
 
 @Deprecated


### PR DESCRIPTION
📝 구현 내용
(가능한 한 자세히 작성해 주시면 감사하겠습니다!)

record, lambda 최신 문법 등의 사용에 제약이 있었기에 버전을 업데이트 했습니다.
- Java 11 -> Java 17
- Spring Boot 2.7.7 -> Spring Boot 3.1.2

이에 따라 다음 작업을 진행했습니다.
- jakarta 패키지로 변경
- feign client 설정 변경
- querydsl 설정 변경

또한 로컬 DB 작업의 편리함을 위해 DB정보를 변경하였습니다.